### PR TITLE
Fix #106.

### DIFF
--- a/packages/conduit-rxjs-react/CHANGELOG.md
+++ b/packages/conduit-rxjs-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.1
+
+Published June XX, 2022
+
+1. Update `props$.next()` call to verify we have an `Observable` with a `next` property (#106).
+
 ## v0.7.0
 
 Published January 13, 2022

--- a/packages/conduit-rxjs-react/src/connect.js
+++ b/packages/conduit-rxjs-react/src/connect.js
@@ -87,8 +87,8 @@ export function connect (WrappedComponent, source, ...args) {
     }
 
     UNSAFE_componentWillReceiveProps (nextProps) {
-      if (this.props$) {
-        this.props$.next(nextProps)
+      if (isObservable(this.props$)) {
+        this.props$.next?.(nextProps)
       }
     }
 

--- a/packages/conduit-rxjs/CHANGELOG.md
+++ b/packages/conduit-rxjs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.1
+
+Published June XX, 2022
+
+1. Update `source.next()` and `subject$.next()` calls to verify we have an `Observable` with a `next` property (#106).
+
 ## v0.6.0
 
 Published January 13, 2022

--- a/packages/conduit-rxjs/src/createHandlers.js
+++ b/packages/conduit-rxjs/src/createHandlers.js
@@ -27,7 +27,7 @@ export function createHandlers (source) {
 
 function createHandler (source) {
   return isObservable(source)
-    ? function handler (value) { return source.next(value) }
+    ? function handler (value) { return source.next?.(value) }
     : null
 }
 

--- a/packages/conduit-rxjs/src/run.js
+++ b/packages/conduit-rxjs/src/run.js
@@ -32,7 +32,9 @@ function subscribeToDomain (domain) {
     .subscribe((nextValues) =>
       Object.keys(nextValues)
         .map((key) => ({ subject$: values[`${key}$`], nextValue: nextValues[key] }))
-        .filter(({ subject$ }) => subject$)
-        .forEach(({ subject$, nextValue }) => subject$.next(nextValue))
+        .filter(({ subject$ }) => isObservable(subject$))
+        .forEach(({ subject$, nextValue }) => {
+          return subject$.next?.(nextValue)
+        })
     )
 }


### PR DESCRIPTION
check source `isObservable` and has `next` property before calling `next()`

Will need to update the publish date in the change log before publishing.