### PR TITLE
Fix #108. remove peer dep versions from readme

### DIFF
--- a/packages/conduit-rxjs-react/README.md
+++ b/packages/conduit-rxjs-react/README.md
@@ -5,8 +5,8 @@ Conduit utilities for connecting RxJS streams to React.
 ## Installation
 
 Install peer dependencies:
-- [`react`](https://github.com/facebook/react) `>= 0.14.0`
-- [`rxjs`](https://github.com/ReactiveX/rxjs) `>= 6.2.0`
+- [`react`](https://github.com/facebook/react)
+- [`rxjs`](https://github.com/ReactiveX/rxjs)
 
 Then install this package.
 

--- a/packages/conduit-rxjs/README.md
+++ b/packages/conduit-rxjs/README.md
@@ -5,7 +5,7 @@ RxJS utilities to support UI architectures.
 ## Installation
 
 Install peer dependencies:
-- [`rxjs`](https://github.com/ReactiveX/rxjs) `>= 6.2.0`
+- [`rxjs`](https://github.com/ReactiveX/rxjs)
 
 Then install this package:
 


### PR DESCRIPTION
Should we mention looking at `package.json` for current versions?